### PR TITLE
docs: 新增双语 API 参考手册并重构项目文档体系

### DIFF
--- a/Docs/API_EN.md
+++ b/Docs/API_EN.md
@@ -1,0 +1,327 @@
+## MagnitudeFormatter - Public API
+
+#### MagnitudeFormatter
+```csharp
+/// <summary>
+/// A general-purpose magnitude numeric formatter.
+/// </summary>
+public static class MagnitudeFormatter
+{
+    /// <param name="steps">
+    /// Array of magnitude step bases.<br />
+    /// Length should be units.Length - 1.
+    /// </param>
+    /// <param name="units">Array of units (e.g., ["B", "KB", "MB"] or ["s", "min", "h"])</param>
+    /// <param name="decimalPlaces">Number of decimal places to retain</param>
+    /// <param name="addSpace">Whether to add a space between the value and the unit (default: true)</param>
+    /// <remarks>Values less than 1 will be returned directly!!!</remarks>
+    public static string Format(
+        double value,
+        string[] units,
+        double[] steps,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+    
+    /// <param name="units">Array of units (e.g., ["B", "KB", "MB"] or ["s", "min", "h"])</param>
+    /// <param name="decimalPlaces">Number of decimal places to retain</param>
+    /// <param name="addSpace">Whether to add a space between the value and the unit (default: true)</param>
+    /// <param name="fixedStep">
+    /// The fixed step size used when the 'steps' array is not provided.
+    /// This implementation prioritizes the 'steps' array; if 'steps' is empty, it falls back to 'fixedStep'.
+    /// </param>
+    /// <remarks>Values less than 1 will be returned directly!!!</remarks>
+    public static string Format(
+        double value,
+        string[] units,
+        int fixedStep = 1000,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+    
+    /// <param name="magnitude">Integrated unit and step data</param>
+    /// <param name="decimalPlaces">Number of decimal places to retain</param>
+    /// <param name="addSpace">Whether to add a space between the value and the unit (default: true)</param>
+    /// <remarks>Values less than 1 will be returned directly!!!</remarks>
+    public static string Format(
+        double value,
+        MagnitudeConfig magnitude,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+}
+```
+
+#### MagnitudeConfig
+
+```csharp
+public record MagnitudeConfig
+{
+    private MagnitudeConfig(string[] units, double[]? steps, double fixedStep, bool isVariable);
+    
+    /// <summary> Units </summary>
+    public string[] Units { get; init; }
+    /// <summary> Variable steps </summary>
+    public double[]? Steps { get; init; }
+    /// <summary> Fixed step </summary>
+    public double FixedStep { get; init; }
+    /// <summary> Flag indicating whether variable steps are used </summary>
+    public bool IsVariable { get; init; }
+
+    /// <summary>
+    /// [Factory Method] Creates a fixed-step system.
+    /// </summary>
+    public static MagnitudeConfig CreateFixed(string[] units, double step);
+
+    /// <summary>
+    /// [Factory Method] Creates a variable-step system.
+    /// </summary>
+    public static MagnitudeConfig CreateVariable(string[] units, double[] steps);
+    
+    public override string ToString();
+}
+```
+
+#### MagnitudePreset
+
+```csharp
+/// <summary> Presets for common magnitude units </summary>
+public static class MagnitudePreset
+{
+    /// <summary> File size units (Binary, base 1024) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig FileSizeBinary;
+
+    /// <summary> Disk capacity / Network traffic units (Decimal, base 1000, compliant with SI standards) </summary>
+    /// <remarks>Hard drive manufacturers and ISPs typically use base 1000 (KB=1000B), not 1024.</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig DataSizeDecimal;
+
+    /// <summary> Time units (Variable steps: 60, 60, 24, 7) </summary>
+    /// <remarks>Seconds -> Minutes -> Hours -> Days -> Weeks</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig TimeStandard;
+
+    /// <summary> Time units (High precision, includes milliseconds) </summary>
+    /// <remarks>Milliseconds -> Seconds -> Minutes -> Hours -> Days</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig TimeHighPrecision;
+
+    /// <summary> Frequency units (Hertz, base 1000) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig Frequency;
+
+    /// <summary> Count magnitude abbreviations (Thousand/Million/Billion) </summary>
+    /// <remarks>Commonly used for displaying user counts, likes, etc. (e.g., 1.5K, 2.3M)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig CountAbbreviation;
+
+    /// <summary> Computer memory / Bandwidth rate (Bitrate, base 1000) </summary>
+    /// <remarks>Network speeds typically use bps, Kbps, Mbps (base 1000)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig Bitrate;
+    
+    /// <summary> Length units (Metric, base 1000) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig LengthMetric;
+        
+    /// <summary> Length units (Imperial, variable steps) </summary>
+    /// <remarks>Inches -> Feet (12) -> Yards (3) -> Miles (1760)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig LengthImperial;
+}
+```
+
+## FileSizeUtil - Public API
+
+```csharp
+public static class FileSizeUtil
+{
+    /// <summary>
+    /// Calculates the file size at the specified path.
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns></returns>
+    /// <exception cref="GetFileSizeException"></exception>
+    public static long CalFileSize(string filePath);
+    
+    /// <summary>
+    /// Formats a byte count into a human-readable file size.
+    /// </summary>
+    public static string GetFileSize(string filePath, int decimalPlaces = 2);
+}
+```
+
+## I18N - Public API
+
+```csharp
+/// <summary>
+/// An I18N class managing all language-to-translation dictionaries.
+///
+/// Requires setting the DatabaseServer object before first use.
+/// </summary>
+public class I18N
+{
+    #region Static
+    /// <summary>
+    /// The key for the connector string translation in a specified language.
+    /// <remarks>e.g., uses '' (empty) for Chinese, ' ' (space) for English</remarks>
+    /// </summary>
+    public const string LinkTagKey = "LinkTag";
+    /// <summary> Providing this symbol in a key allows concatenating multiple key values into a single translation. </summary>
+    public const string LinkKeySymbol = "::";
+    /// <summary> Gets an I18N instance by name. </summary>
+    [UsedImplicitly]
+    public static I18N? GetI18N(string name) => I18NStatics.GetValueOrDefault(name);
+    /// <summary> Gets an I18N instance by name. <br /> Creates a new instance if one with the specified name does not exist. </summary>
+    [UsedImplicitly]
+    public static I18N GetOrCreateI18N(string name) => I18NStatics.GetValueOrDefault(name) ?? new I18N(name);
+    /// <summary> Data Server </summary>
+    public static DatabaseServer? DatabaseServer { get; set; }
+    /// <summary>
+    /// Initializes the DatabaseServer.
+    /// </summary>
+    [UsedImplicitly] public static void Initialize(DatabaseServer databaseServer);
+    #endregion
+
+    #region Instance
+
+    public I18N(string name);
+    /// <summary> Default separator for the I18N instance. </summary>
+    public string DefaultLinkTag { get; [UsedImplicitly] set; } = " ";
+    /// <summary> Separator for the current language. </summary>
+    [UsedImplicitly] public string LinkTag => _linkTags.GetValueOrDefault(CurrentLang, DefaultLinkTag);
+    /// <summary> Name. </summary>
+    public string Name { get; private set; }
+    /// <summary> Gets the SPT translation database corresponding to the current language. </summary>
+    public Dictionary<string, string>? SptLocals => _sptLocals ??= GetSptLocals();
+    /// <summary> Read-only property to view supported languages. </summary>
+    [UsedImplicitly] public List<string> AvailableLang => _i18N.Keys.ToList();
+    /// <summary> Current language. </summary>
+    /// <exception cref="I18NNameAlreadyExistException"></exception>
+    /// <exception cref="NotLoadLanguageException"></exception>
+    public string CurrentLang { get; set; }
+
+    /// <summary>
+    /// Loads all language files with the format 'xx.json' from the specified folder.
+    /// </summary>
+    /// <exception cref="LoadLocalDBException"></exception>
+    /// <exception cref="DirectoryNotFoundException"></exception>
+    [UsedImplicitly] public void LoadFolders(string path);
+
+    /// <summary>
+    /// Adds a translation entry for a specified language.
+    /// </summary> 
+    public void Add(string lang, string key, string value);
+
+    /// <summary>
+    /// Removes the translation data for a specific key in a specified language.
+    /// </summary>
+    [UsedImplicitly] public void Remove(string lang, string key);
+    
+    /// <summary>
+    /// Removes all data for a specified language.
+    /// </summary>
+    [UsedImplicitly] public void Remove(string lang);
+    
+    /// <summary>
+    /// Extends translation information for a specified language via a dictionary (overwrites existing keys).
+    /// </summary>
+    /// <returns>Set of overwritten keys</returns>
+    /// <exception cref="IllegalTranslationKeyException"></exception>
+    [UsedImplicitly] public HashSet<string> Expand(string lang, Dictionary<string, string> value);
+
+    /// <summary>
+    /// Adds a translation entry for the current language.
+    /// </summary>
+    [UsedImplicitly] public void Add(string key, string value);
+
+    /// <summary>
+    /// Gets a formatted string with parameters.
+    /// <remarks>Parameters in the string must be in the {{variable_name}} format.</remarks>
+    /// </summary>
+    /// <param name="msg">Formatted string with parameters</param>
+    /// <param name="args">Parameter object</param>
+    public static string DumpFormatStrLocal(string msg, object args);
+    
+    /// <summary>
+    /// Gets localized text.
+    /// </summary>
+    /// <param name="key">Localization key</param>
+    /// <param name="args">Optional parameter object; properties will replace {{property_name}} in the string</param>
+    /// <remarks>Multiple key translations can be concatenated using :: <br/> e.g., "key1::key2" </remarks>
+    /// <returns>The localized string</returns>
+    public string Translate(string key, object? args = null);
+}
+```
+
+## ModLogger - Public API
+
+```csharp
+/// <summary> Strategy for ModLogger instance log recording. </summary>
+public enum ModLoggerStrategy
+{
+    /// <summary> Single file logging. </summary>
+    SingleFile,
+    /// <summary> Multi-file logging. </summary>
+    MultiFile
+}
+```
+
+```csharp
+/// <summary>
+/// Enables mods to record detailed logs within the mod folder.
+/// <br />
+/// Facilitates testing/debugging.
+/// Prevents cluttering the SPT server logs.
+/// </summary>
+public class ModLogger : IDisposable
+{
+    #region Static
+    public const string DefaultLogFolderPath = "user/mods/SuntionCore/ModLogs";
+    /// <summary> Sets the default maximum log file size. The original file is deleted when this limit is exceeded. <remarks>Used when the logFileMaxSize parameter is set to 0.</remarks> </summary>
+    public static long TotalDefaultLogFileMaxSize { get; [UsedImplicitly] set; } = 1 * 1024 * 1024;
+    [UsedImplicitly] public static ModLogger? GetLogger(string name);
+    /// <summary> Gets a ModLogger instance by name. <br /> Creates a new instance if one with the specified name does not exist. </summary>
+    [UsedImplicitly]
+    public static ModLogger GetOrCreateLogger(string name, ModLoggerStrategy strategy = ModLoggerStrategy.SingleFile,
+        string folderPath = DefaultLogFolderPath, long logFileMaxSize = 0);
+    /// <summary> Number of registered logger instances. </summary>
+    public static long LoggerCount { get {
+        lock (StaticLock)
+        {
+            return Loggers.Count;
+        }
+    } }
+    /// <summary> Iterates over registered logger instances. </summary>
+    public static Dictionary<string, ModLogger> Items { get {
+        lock (StaticLock)
+        {
+            return Loggers;
+        }
+    } }
+
+    #endregion
+
+    #region Instance
+
+    /// <summary> Initializes the instance. </summary>
+    /// <param name="modName">Unique mod name or Guid</param>
+    /// <param name="strategy">Log recording strategy</param>
+    /// <param name="folderPath">Folder path for recording logs</param>
+    /// <param name="logFileMaxSize">Sets the maximum log file size; the original file is deleted when exceeded. Unit: Bytes</param>
+    /// <exception cref="ArgumentNullException">Error thrown when modName is not provided</exception>
+    public ModLogger(string modName, ModLoggerStrategy strategy = ModLoggerStrategy.SingleFile, 
+        string folderPath = DefaultLogFolderPath, long logFileMaxSize = 0);
+    
+    /// <summary> Mod name. </summary>
+    public string ModName { get; }
+    /// <summary> Folder path for recording logs. </summary>
+    public string FolderPath { get; [UsedImplicitly] set; }
+    /// <summary> Sets the maximum log file size; the original file is deleted when exceeded. </summary>
+    public long LogFileMaxSize { get; [UsedImplicitly] set; }
+    /// <summary> Log recording strategy. </summary>
+    public ModLoggerStrategy Strategy { get; [UsedImplicitly] set; }
+    
+    /// <summary> Records a local log entry, then returns the log entry prefixed with the mod name. </summary>
+    [UsedImplicitly] public string Info(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.InfoStream, message, ex)}";
+    /// <summary> Records a local log entry, then returns the log entry prefixed with the mod name. </summary>
+    [UsedImplicitly] public string Warn(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.WarningStream, message, ex)}";
+    /// <summary> Records a local log entry, then returns the log entry prefixed with the mod name. </summary>
+    [UsedImplicitly] public string Debug(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.DebugStream, message, ex)}";
+    /// <summary> Records a local log entry, then returns the log entry prefixed with the mod name. </summary>
+    [UsedImplicitly] public string Error(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.ErrorStream, message, ex)}";
+    
+    public void Dispose();
+    
+    #endregion
+}
+```

--- a/Docs/API_ZH.md
+++ b/Docs/API_ZH.md
@@ -1,0 +1,326 @@
+## MagnitudeFormatter - 公有接口
+
+#### MagnitudeFormatter
+```csharp
+/// <summary>
+/// 通用的量级数值格式化器
+/// </summary>
+public static class MagnitudeFormatter
+{
+    /// <param name="steps">
+    /// 量级间隔基数数组。<br />
+    /// 长度应为 units.Length - 1。
+    /// </param>
+    /// <param name="units">单位数组 (例如：["B", "KB", "MB"] 或 ["s", "min", "h"])</param>
+    /// <param name="decimalPlaces">保留小数位数</param>
+    /// <param name="addSpace">数值和单位之间是否添加空格 (默认 true)</param>
+    /// <remarks>小于1的数会直接返回!!!</remarks>
+    public static string Format(
+        double value,
+        string[] units,
+        double[] steps,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+    
+    /// <param name="units">单位数组 (例如：["B", "KB", "MB"] 或 ["s", "min", "h"])</param>
+    /// <param name="decimalPlaces">保留小数位数</param>
+    /// <param name="addSpace">数值和单位之间是否添加空格 (默认 true)</param>
+    /// <param name="fixedStep">
+    /// 当 steps 未提供时使用的固定步长。
+    /// 本实现优先使用 steps 数组，若 steps 为空则回退到 fixedStep。
+    /// </param>
+    /// <remarks>小于1的数会直接返回!!!</remarks>
+    public static string Format(
+        double value,
+        string[] units,
+        int fixedStep = 1000,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+    
+    /// <param name="magnitude">整合的单位与步长数据</param>
+    /// <param name="decimalPlaces">保留小数位数</param>
+    /// <param name="addSpace">数值和单位之间是否添加空格 (默认 true)</param>
+    /// <remarks>小于1的数会直接返回!!!</remarks>
+    public static string Format(
+        double value,
+        MagnitudeConfig magnitude,
+        int decimalPlaces = 2,
+        bool addSpace = true);
+}
+```
+
+#### MagnitudeConfig
+
+```csharp
+public record MagnitudeConfig
+{
+    private MagnitudeConfig(string[] units, double[]? steps, double fixedStep, bool isVariable);
+    
+    /// <summary> 单位 </summary>
+    public string[] Units { get; init; }
+    /// <summary> 可变步长 </summary>
+    public double[]? Steps { get; init; }
+    /// <summary> 固定步长 </summary>
+    public double FixedStep { get; init; }
+    /// <summary> 是否是可变步长的标志 </summary>
+    public bool IsVariable { get; init; }
+
+    /// <summary>
+    /// 【工厂方法】创建固定步长系统
+    /// </summary>
+    public static MagnitudeConfig CreateFixed(string[] units, double step);
+
+    /// <summary>
+    /// 【工厂方法】创建可变步长系统
+    /// </summary>
+    public static MagnitudeConfig CreateVariable(string[] units, double[] steps);
+    
+    public override string ToString();
+}
+```
+
+#### MagnitudePreset
+
+```csharp
+/// <summary> 常用数量级单位预设 </summary>
+public static class MagnitudePreset
+{
+    /// <summary> 文件尺寸单位 (二进制，1024) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig FileSizeBinary;
+
+    /// <summary> 磁盘容量/网络流量单位 (十进制，1000，符合 SI 标准) </summary>
+    /// <remarks>硬盘厂商和网络运营商通常使用 1000 进制 (KB=1000B)，而非 1024。</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig DataSizeDecimal;
+
+    /// <summary> 时间单位 (变步长：60, 60, 24, 7) </summary>
+    /// <remarks>秒 -> 分 -> 时 -> 天 -> 周</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig TimeStandard;
+
+    /// <summary> 时间单位 (高精度，含毫秒) </summary>
+    /// <remarks>毫秒 -> 秒 -> 分 -> 时 -> 天</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig TimeHighPrecision;
+
+    /// <summary> 频率单位 (赫兹，1000) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig Frequency;
+
+    /// <summary> 数据数量级缩写 (千/百万/十亿) </summary>
+    /// <remarks>常用于显示用户数、点赞数等 (e.g., 1.5K, 2.3M)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig CountAbbreviation;
+
+    /// <summary> 计算机内存/带宽速率 (比特率，1000) </summary>
+    /// <remarks>网络速度通常用 bps, Kbps, Mbps (1000 进制)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig Bitrate;
+    
+    /// <summary> 长度单位 (公制，1000) </summary>
+    [UsedImplicitly] public static readonly MagnitudeConfig LengthMetric;
+        
+    /// <summary> 长度单位 (英制，变步长) </summary>
+    /// <remarks>英寸 -> 英尺 (12) -> 码 (3) -> 英里 (1760)</remarks>
+    [UsedImplicitly] public static readonly MagnitudeConfig LengthImperial;
+}
+```
+
+## FileSizeUtil - 公有接口
+
+```csharp
+public static class FileSizeUtil
+{
+    /// <summary>
+    /// 计算路径的文件的尺寸
+    /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns></returns>
+    /// <exception cref="GetFileSizeException"></exception>
+    public static long CalFileSize(string filePath);
+    
+    /// <summary>
+    /// 将字节数格式化为可读的文件大小
+    /// </summary>
+    public static string GetFileSize(string filePath, int decimalPlaces = 2);
+}
+```
+
+## I18N - 公有接口
+
+```csharp
+/// <summary>
+/// 一个I18N类管理所有语言->翻译字典
+///
+/// 首次使用需要设置DatabaseServer对象
+/// </summary>
+public class I18N
+{
+    #region 静态
+    /// <summary>
+    /// 指定语言中用于连接的字符串译文的键
+    /// <remarks>例如中文用''分隔, 英文用' '分隔</remarks>
+    /// </summary>
+    public const string LinkTagKey = "LinkTag";
+    /// <summary> 在键中提供该符号, 可以连接多个键的值为一条译文 </summary>
+    public const string LinkKeySymbol = "::";
+    /// <summary> 根据I18N的名称获取I18N实例 </summary>
+    [UsedImplicitly]
+    public static I18N? GetI18N(string name) => I18NStatics.GetValueOrDefault(name);
+    /// <summary> 根据I18N的名称获取I18N实例 <br /> 如果指定名称的实例不存在时创建新的 </summary>
+    [UsedImplicitly]
+    public static I18N GetOrCreateI18N(string name) => I18NStatics.GetValueOrDefault(name) ?? new I18N(name);
+    /// <summary> 数据服务器 </summary>
+    public static DatabaseServer? DatabaseServer { get; set; }
+    /// <summary>
+    /// 初始化DatabaseServer
+    /// </summary>
+    [UsedImplicitly] public static void Initialize(DatabaseServer databaseServer);
+    #endregion
+
+    #region 实例
+
+    public I18N(string name);
+    /// <summary> I18N实例默认分隔符 </summary>
+    public string DefaultLinkTag { get; [UsedImplicitly] set; } = " ";
+    /// <summary> 当前语言的分隔符 </summary>
+    [UsedImplicitly] public string LinkTag => _linkTags.GetValueOrDefault(CurrentLang, DefaultLinkTag);
+    /// <summary> 名称 </summary>
+    public string Name { get; private set; }
+    /// <summary> 获取当前语言对应的SPT译文数据库 </summary>
+    public Dictionary<string, string>? SptLocals => _sptLocals ??= GetSptLocals();
+    /// <summary> 只读属性, 查看支持的语言 </summary>
+    [UsedImplicitly] public List<string> AvailableLang => _i18N.Keys.ToList();
+    /// <summary> 当前语言 </summary>
+    /// <exception cref="I18NNameAlreadyExistException"></exception>
+    /// <exception cref="NotLoadLanguageException"></exception>
+    public string CurrentLang { get; set; }
+
+    /// <summary>
+    /// 加载指定文件夹下所有格式为'xx.json'格式的语言文件
+    /// </summary>
+    /// <exception cref="LoadLocalDBException"></exception>
+    /// <exception cref="DirectoryNotFoundException"></exception>
+    [UsedImplicitly] public void LoadFolders(string path);
+
+    /// <summary>
+    /// 为指定语言添加一条译文
+    /// </summary> public void Add(string lang, string key, string value);
+
+    /// <summary>
+    /// 删除指定语言的指定一个键的翻译数据
+    /// </summary>
+    [UsedImplicitly] public void Remove(string lang, string key);
+    
+    /// <summary>
+    /// 删除指定语言的所有数据
+    /// </summary>
+    [UsedImplicitly] public void Remove(string lang);
+    
+    /// <summary>
+    /// 通过字典扩展指定语言的翻译信息(覆盖已存在键)
+    /// </summary>
+    /// <returns>覆盖过的键的集合</returns>
+    /// <exception cref="IllegalTranslationKeyException"></exception>
+    [UsedImplicitly] public HashSet<string> Expand(string lang, Dictionary<string, string> value);
+
+    /// <summary>
+    /// 为当前语言添加一条译文
+    /// </summary>
+    [UsedImplicitly] public void Add(string key, string value);
+
+    /// <summary>
+    /// 获取带参数的格式化字符串
+    /// <remarks>字符串中的参数必须是{{变量名}}格式</remarks>
+    /// </summary>
+    /// <param name="msg">有参数格式化字符串</param>
+    /// <param name="args">参数对象</param>
+    public static string DumpFormatStrLocal(string msg, object args);
+    
+    /// <summary>
+    /// 获取本地化文本
+    /// </summary>
+    /// <param name="key">本地化键</param>
+    /// <param name="args">可选参数对象，属性将替换字符串中的{{属性名}}</param>
+    /// <remarks>可以使用 :: 连接多个键的译文 <br/> 例如 "key1::key2" </remarks>
+    /// <returns>本地化后的字符串</returns>
+    public string Translate(string key, object? args = null);
+}
+```
+
+## ModLogger - 公有接口
+
+```csharp
+/// <summary> ModLogger实例记录日志的策略 </summary>
+public enum ModLoggerStrategy
+{
+    /// <summary> 单文件日志 </summary>
+    SingleFile,
+    /// <summary> 多文件日志 </summary>
+    MultiFile
+}
+```
+
+```csharp
+/// <summary>
+/// 用于使得模组在模组文件夹下记录详细日志
+/// <br />
+/// 方便测试 / 调试
+/// 避免SPT服务器的日志过于繁琐
+/// </summary>
+public class ModLogger: IDisposable
+{
+    #region 静态
+    public const string DefaultLogFolderPath = "user/mods/SuntionCore/ModLogs";
+    /// <summary> 设置默认日志文件大小上限, 超出上限后删除原文件 <remarks>当logFileMaxSize参数设置为0时使用</remarks> </summary>
+    public static long TotalDefaultLogFileMaxSize { get; [UsedImplicitly] set; } = 1 * 1024 * 1024;
+    [UsedImplicitly] public static ModLogger? GetLogger(string name);
+    /// <summary> 根据ModLogger的名称获取ModLogger实例 <br /> 如果指定名称的实例不存在时创建新的 </summary>
+    [UsedImplicitly]
+    public static ModLogger GetOrCreateLogger(string name, ModLoggerStrategy strategy = ModLoggerStrategy.SingleFile,
+        string folderPath = DefaultLogFolderPath, long logFileMaxSize = 0);
+    /// <summary> 注册的日志实例数量 </summary>
+    public static long LoggerCount { get {
+        lock (StaticLock)
+        {
+            return Loggers.Count;
+        }
+    } }
+    /// <summary> 遍历注册的日志实例 </summary>
+    public static Dictionary<string, ModLogger> Items { get {
+        lock (StaticLock)
+        {
+            return Loggers;
+        }
+    } }
+
+    #endregion
+
+    #region 实例
+
+    /// <summary> 初始化实例 </summary>
+    /// <param name="modName">模组唯一名称或者Guid</param>
+    /// <param name="strategy">记录日志的策略</param>
+    /// <param name="folderPath">记录日志的文件夹路径</param>
+    /// <param name="logFileMaxSize">设置日志文件大小上限, 超出上限后删除原文件 单位: B</param>
+    /// <exception cref="ArgumentNullException">没有提供modName时的错误</exception>
+    public ModLogger(string modName, ModLoggerStrategy strategy = ModLoggerStrategy.SingleFile, 
+        string folderPath = DefaultLogFolderPath, long logFileMaxSize = 0);
+    
+    /// <summary> 模组名称 </summary>
+    public string ModName { get; }
+    /// <summary> 记录日志的文件夹路径 </summary>
+    public string FolderPath { get; [UsedImplicitly] set; }
+    /// <summary> 设置日志文件大小上限, 超出上限后删除原文件 </summary>
+    public long LogFileMaxSize { get; [UsedImplicitly] set; }
+    /// <summary> 日志记录策略 </summary>
+    public ModLoggerStrategy Strategy { get; [UsedImplicitly] set; }
+    
+    /// <summary> 记录一条本地日志, 随后返回使用模组名称修饰的日志条目 </summary>
+    [UsedImplicitly] public string Info(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.InfoStream, message, ex)}";
+    /// <summary> 记录一条本地日志, 随后返回使用模组名称修饰的日志条目 </summary>
+    [UsedImplicitly] public string Warn(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.WarningStream, message, ex)}";
+    /// <summary> 记录一条本地日志, 随后返回使用模组名称修饰的日志条目 </summary>
+    [UsedImplicitly] public string Debug(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.DebugStream, message, ex)}";
+    /// <summary> 记录一条本地日志, 随后返回使用模组名称修饰的日志条目 </summary>
+    [UsedImplicitly] public string Error(string message, Exception? ex = null) => $"[{ModName}] {LogMessage(LogWriterStream.ErrorStream, message, ex)}";
+    
+    public void Dispose();
+    
+    #endregion
+}
+```

--- a/Docs/README_ZH.md
+++ b/Docs/README_ZH.md
@@ -6,6 +6,11 @@
 
 ## 提供的功能
 
+- [类型扩展速览](#类型扩展速览)
+  - 将多语言功能, 文件尺寸计算功能扩展到字符串的成员函数, 方便于使用
+- [MagnitudeFormatter - 按单位格式化数值工具](#magnitudeformatter---按单位格式化数值工具)
+  - 提供封住的单位类型`MagnitudeConfig`以及常用单位的预设`MagnitudePreset`
+  - 支持根据步长格式化数值为格式化字符串: 如 12.12 KB 36.24 MB 等
 - [FileSizeUtil - 文件尺寸工具](#filesizeutil---文件尺寸工具)
   - 直接使用静态类`FileSizeUtil`
   - 使用字符串扩展`ToFileSize`或`CalFileSize`
@@ -19,7 +24,7 @@
   - 默认日志文件夹路径: `user/mods/SuntionCore/ModLogs`(存在模组使用该日志时才会在服务器加载完毕后输出日志文件夹路径->该路径下的模组的信息)
 
 
-### 字符串扩展速览
+## 类型扩展速览
 
 ```csharp
 /// <summary>
@@ -57,20 +62,21 @@ public static string Translate(this string? value, I18N local, object? args = nu
 | "key1::key2".Translate(i18N);                            | 在翻译文件中keyx对应的值为valuex<br/>当前语言默认LinkTag对应的值为- | (String)(value1-value2)          |
 | "key1".Translate(i18N, new { Name = "a", Count = "b" }); | 在翻译文件中key1对应的值为"value1: Name={{Name}} Count={{Count}}" | (String)(value1: Name=a Count=b) |
 
-这份文档是为您准备的项目 README 或 Wiki 内容，旨在清晰地展示 `FileSizeUtil`、`I18N` 和 `ModLogger` 三个核心工具类的功能、用法及注意事项。您可以直接将其复制到 GitHub 的 `README.md` 或项目的 `docs` 文件夹中。
-
 ---
+
+## MagnitudeFormatter - 按单位格式化数值工具
+
+位于 `public static class MagnitudeFormatter`, 提供静态方法用于根据单位与步长的配置格式化数值
+
+[API参考](API_ZH.md#magnitudeformatter---公有接口)
+
+### 使用示例
+
+参考`SuntionCore.Tests/Services/MagnitudeFormatterTest.cs`
 
 ## FileSizeUtil - 文件尺寸工具
 
-位于 `public static class FileSizeUtil`，提供静态方法用于快速获取文件大小并将其转换为人类可读的格式。
-
-### 🔧 功能概览
-
-| 方法名        | 描述                                                         | 返回值          |
-| :------------ | :----------------------------------------------------------- | :-------------- |
-| `CalFileSize` | 计算指定路径文件的实际字节大小。                             | `long` (字节数) |
-| `GetFileSize` | 获取指定路径文件的大小，并自动格式化为可读字符串（如 "1.5 MB"）。 | `string`        |
+[API参考](API_ZH.md#filesizeutil---公有接口)
 
 ### 💡 使用示例
 
@@ -97,8 +103,6 @@ string preciseSize = FileSizeUtil.GetFileSize(filePath, decimalPlaces: 4);
 
 ## I18N - 国际化多语言管理
 
-`I18N` 类是一个强大的多语言管理系统，支持动态加载语言包、键值连接、参数化替换等功能。
-
 ### 🚀 核心特性
 - **单例/多实例管理**：通过名称管理多个独立的翻译上下文。
 - **动态加载**：支持从文件夹批量加载 `xx.json` 格式的语言文件。
@@ -106,9 +110,11 @@ string preciseSize = FileSizeUtil.GetFileSize(filePath, decimalPlaces: 4);
 - **参数化替换**：支持 `{{变量名}}` 格式的字符串插值。
 - **数据库集成**：可选集成 `DatabaseServer` 进行持久化存储。
 
+[API参考](API_ZH.md#i18n---公有接口)
+
 ### 🛠️ 初始化与配置
 
-在使用前，建议初始化全局数据库服务器（如果需要持久化）：
+在使用前，建议初始化全局数据库服务器（如果需要使用SptLocals时）:
 
 ```csharp
 // 设置全局数据库服务器
@@ -173,15 +179,6 @@ string text3 = i18n.Translate("reward_msg", args);
 // 输出：玩家 PlayerOne 获得了 5 个物品
 ```
 
-### 📊 属性说明
-
-| 属性            | 类型           | 描述                                                         |
-| :-------------- | :------------- | :----------------------------------------------------------- |
-| `CurrentLang`   | `string`       | 当前激活的语言代码 (如 "zh", "en")。设置时会验证长度和加载状态。 |
-| `AvailableLang` | `List<string>` | 只读，列出当前实例已加载的所有语言代码。                     |
-| `LinkTag`       | `string`       | 当前语言使用的连接符 (由 `LinkTagKey` 配置决定，默认为空格)。 |
-| `SptLocals`     | `Dictionary`   | 获取当前语言对应的完整翻译字典。                             |
-
 ### ⚠️ 异常提示
 - **`NotLoadLanguageException`**: 尝试切换到未加载的语言时抛出。
 - **`I18NNameAlreadyExistException`**: 语言代码长度不为 2 或命名冲突时抛出。
@@ -192,6 +189,8 @@ string text3 = i18n.Translate("reward_msg", args);
 ## ModLogger - 模块化日志系统
 
 `ModLogger` 专为模组开发设计，旨在将模组的详细日志与主服务器日志分离，便于调试且避免污染主日志流。
+
+[API参考](API_ZH.md#modlogger---公有接口)
 
 ### 🌟 主要特点
 - **独立文件**：每个模组拥有独立的日志文件或流。
@@ -250,23 +249,6 @@ var specificLogger = ModLogger.GetLogger("OtherMod");
 
 // 查看注册数量
 long count = ModLogger.LoggerCount;
-```
-
-### ⚙️ 配置项
-
-| 配置项                       | 类型           | 说明                                                         |
-| :--------------------------- | :------------- | :----------------------------------------------------------- |
-| `DefaultLogFolderPath`       | `const string` | 默认日志存储路径 (`user/mods/SuntionCore/ModLogs`)。         |
-| `TotalDefaultLogFileMaxSize` | `static long`  | 全局默认文件大小上限 (默认 1GB)。当实例构造参数为 0 时生效。 |
-| `Strategy`                   | `Enum`         | 日志写入策略 (`SingleFileStream`, `InfoStream`, `ErrorStream` 等)。 |
-| `LogFileMaxSize`             | `long`         | 实例级别的文件大小上限 (单位：Byte)。                        |
-
-### ♻️ 资源释放
-`ModLogger` 实现了 `IDisposable` 接口。在模组卸载或程序退出时，请务必调用 `Dispose()` 以释放文件句柄。
-
-```csharp
-// 通常在模组卸载逻辑中
-logger?.Dispose();
 ```
 
 ## 致谢

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The current version includes **File Size Calculation and Formatting**, **Interna
 
 ## Provided Features
 
+- [Type Extension Overview](#type-extension-overview)
+  - Extends string member functions with multi-language support and file size calculation features for easier usage.
+- [MagnitudeFormatter - Unit-based Numeric Formatting Tool](#magnitudeformatter---unit-based-numeric-formatting-tool)
+  - Provides the encapsulated unit type `MagnitudeConfig` and predefined common units via `MagnitudePreset`.
+  - Supports formatting numeric values into strings based on step sizes, e.g., 12.12 KB, 36.24 MB, etc.
 - [FileSizeUtil - File Size Utility](#filesizeutil---file-size-utility)
     - Use the static class `FileSizeUtil` directly
     - Use the string extensions `ToFileSize` or `CalFileSize`
@@ -20,7 +25,7 @@ The current version includes **File Size Calculation and Formatting**, **Interna
     - Use `ModLogger.GetOrCreateLogger(string name, ModLoggerStrategy strategy = ModLoggerStrategy.SingleFile, string folderPath = DefaultLogFolderPath, long logFileMaxSize = 0)` to get or create an instance
     - Default log folder path: `user/mods/SuntionCore/ModLogs` (The folder path for the mod will be output after the server finishes loading only when a mod uses this logging system -> information for mods under that path)
 
-### String Extension Quick Look
+## Type Extension Overview
 
 ```csharp
 /// <summary>
@@ -60,16 +65,19 @@ public static string Translate(this string? value, I18N local, object? args = nu
 
 ---
 
+## MagnitudeFormatter - Unit-based Numeric Formatting Tool
+
+Located in `public static class MagnitudeFormatter`, this class provides static methods to format numeric values according to configured units and step sizes.
+
+[API Reference](Docs/API_EN.md#magnitudeformatter---public-api)
+
+### Usage Examples
+
+Refer to `SuntionCore.Tests/Services/MagnitudeFormatterTest.cs`.
+
 ## FileSizeUtil - File Size Utility
 
-Located in `public static class FileSizeUtil`, it provides static methods for quickly obtaining file sizes and converting them into human-readable formats.
-
-### 🔧 Feature Overview
-
-| Method Name   | Description                                                  | Return Value     |
-| :------------ | :----------------------------------------------------------- | :--------------- |
-| `CalFileSize` | Calculates the actual byte size of the file at the specified path. | `long` (bytes)   |
-| `GetFileSize` | Gets the size of the file at the specified path and automatically formats it into a readable string (e.g., "1.5 MB"). | `string`         |
+[API Reference](Docs/API_EN.md#filesizeutil---public-api)
 
 ### 💡 Usage Examples
 
@@ -107,9 +115,11 @@ The `I18N` class is a powerful multilingual management system that supports dyna
 - **Parameterized Replacement**: Supports string interpolation using the `{{variableName}}` format.
 - **Database Integration**: Optional integration with `DatabaseServer` for persistent storage.
 
+[API Reference](Docs/API_EN.md#i18n---public-api)
+
 ### 🛠️ Initialization and Configuration
 
-Before use, it is recommended to initialize the global database server (if persistence is needed):
+Before use, it is recommended to initialize the global database server (if `SptLocals` is required).
 
 ```csharp
 // Set the global database server
@@ -177,15 +187,6 @@ string text3 = i18n.Translate("reward_msg", args);
 // Output: Player PlayerOne has obtained 5 items
 ```
 
-### 📊 Property Description
-
-| Property        | Type             | Description                                                  |
-| :-------------- | :--------------- | :----------------------------------------------------------- |
-| `CurrentLang`   | `string`         | The currently active language code (e.g., "en", "es"). Setting it validates length and load status. |
-| `AvailableLang` | `List<string>`   | Read-only, lists all language codes currently loaded for this instance. |
-| `LinkTag`       | `string`         | The connector used for the current language (determined by the `LinkTagKey` configuration, default is a space). |
-| `SptLocals`     | `Dictionary`     | Gets the complete translation dictionary for the current language. |
-
 ### ⚠️ Exception Notes
 
 - **`NotLoadLanguageException`**: Thrown when trying to switch to a language that hasn't been loaded.
@@ -204,6 +205,8 @@ string text3 = i18n.Translate("reward_msg", args);
 - **Flexible Strategies**: Supports various strategies like single file rotation (rotates only once when the mod loads, not very suitable for servers like Fika that run continuously) and stream separation by log level (`ModLoggerStrategy`).
 - **Automatic Cleanup**: Configurable file size limit. When the limit is exceeded, old logs are automatically deleted when the server starts using the logs.
 - **Thread Safety**: The static registry uses locking mechanisms to ensure multi-threading safety.
+
+[API Reference](Docs/API_EN.md#modlogger---public-api)
 
 ### 🚀 Quick Start
 
@@ -259,24 +262,6 @@ var specificLogger = ModLogger.GetLogger("OtherMod");
 
 // Check the number of registered loggers
 long count = ModLogger.LoggerCount;
-```
-
-### ⚙️ Configuration Options
-
-| Option                       | Type           | Description                                                  |
-| :--------------------------- | :------------- | :----------------------------------------------------------- |
-| `DefaultLogFolderPath`       | `const string` | Default log storage path (`user/mods/SuntionCore/ModLogs`).  |
-| `TotalDefaultLogFileMaxSize` | `static long`  | Global default file size limit (default 1GB). Effective when the instance constructor parameter is set to 0. |
-| `Strategy`                   | `Enum`         | Log writing strategy (`SingleFileStream`, `InfoStream`, `ErrorStream`, etc.). |
-| `LogFileMaxSize`             | `long`         | Instance-specific file size limit (in bytes).                |
-
-### ♻️ Resource Cleanup
-
-`ModLogger` implements the `IDisposable` interface. When unloading a mod or upon program exit, be sure to call `Dispose()` to release file handles.
-
-```csharp
-// Typically placed in the mod's unload logic
-logger?.Dispose();
 ```
 
 ## Credits


### PR DESCRIPTION
- 新增文档：构建中英文 API 参考手册
  * 新建 `Docs/API_ZH.md` 与 `Docs/API_EN.md`，完整收录核心模块的公有接口定义与 XML 注释
  * 涵盖 `MagnitudeFormatter` (量级格式化)、`MagnitudeConfig` (配置记录) 及 `MagnitudePreset` (预设常量)
  * 收录 `FileSizeUtil` (文件尺寸)、`I18N` (多语言管理) 及 `ModLogger` (模组日志) 的完整方法签名、属性说明及异常提示
  * 确保双语文档结构一致，便于国际化查阅

- 内容重构：优化 README 结构与导航体验
  * 更新根目录 `README.md` (英文) 与 `Docs/README_ZH.md` (中文)：
    - 新增"MagnitudeFormatter"章节，介绍单位格式化功能及预设配置
    - 将原有的详细表格、属性说明及配置项迁移至 API 参考手册
    - 在 README 中保留核心特性介绍、快速开始指南及使用示例
    - 添加指向 `API_*.md` 具体锚点的链接，提升文档跳转效率
  * 文案修正：
    - 明确 `I18N` 初始化说明，指出仅在需要使用 `SptLocals` 时才需配置 `DatabaseServer`
    - 统一术语表达，修复部分语句通顺度问题