### PR TITLE
refactor(file): 重构 FileSizeUtil 以复用通用量级格式化器

### DIFF
--- a/SuntionCore/Services/FileUtils/FileSizeUtil.cs
+++ b/SuntionCore/Services/FileUtils/FileSizeUtil.cs
@@ -1,11 +1,10 @@
 using SuntionCore.Services.FileUtils.Exceptions;
+using SuntionCore.Services.MagnitudeUtils;
 
 namespace SuntionCore.Services.FileUtils;
 
 public static class FileSizeUtil
 {
-    private static readonly string[] SizeUnits = ["B", "KB", "MB", "GB", "TB", "PB", "EB"];
-
     /// <summary>
     /// 计算路径的文件的尺寸
     /// </summary>
@@ -33,18 +32,12 @@ public static class FileSizeUtil
     /// </summary>
     public static string GetFileSize(string filePath, int decimalPlaces = 2)
     {
-        var emptySize = $"0 {SizeUnits[0]}";
+        var emptySize = $"0 {MagnitudePreset.FileSizeBinary.Units[0]}";
         
         if (!File.Exists(filePath)) return emptySize;
 
         long bytes = CalFileSize(filePath);
-        
-        if (bytes == 0) return emptySize;
-        
-        var magnitude = (int)Math.Floor(Math.Log(bytes, 1024));
-        magnitude = Math.Min(magnitude, SizeUnits.Length - 1);
-        
-        var adjustedSize = bytes / Math.Pow(1024, magnitude);
-        return $"{adjustedSize.ToString($"F{decimalPlaces}")} {SizeUnits[magnitude]}";
+
+        return MagnitudeFormatter.Format(bytes, MagnitudePreset.FileSizeBinary, decimalPlaces);
     }
 }


### PR DESCRIPTION
- 代码优化：移除冗余的量级计算逻辑
  * 删除 `FileSizeUtil` 内部硬编码的 `SizeUnits` 数组
  * 移除手动计算量级索引 (`Math.Log`)、幂运算 (`Math.Pow`) 及边界检查的重复代码
  * 消除对魔法数字 `1024` 的直接依赖

- 架构改进：集成 MagnitudeFormatter 核心能力
  * 引入 `SuntionCore.Services.MagnitudeUtils` 命名空间
  * 重写 `GetFileSize` 方法，直接调用 `MagnitudeFormatter.Format` 并传入 `MagnitudePreset.FileSizeBinary` 预设配置
  * 统一文件尺寸格式化行为，确保与全局量级处理逻辑（如小数位控制、空格处理）保持一致