### PR TITLE
[DEV] 开发SuntionCore.SPTExtensions的v1.0.*版本

### DIFF
--- a/SuntionCore.SPTExtensions/Services/ModMailService.cs
+++ b/SuntionCore.SPTExtensions/Services/ModMailService.cs
@@ -30,6 +30,7 @@ public class ModMailService(
     private const string KeySendMoneyError = nameof(KeySendMoneyError);
     private const string KeyNoItemsSpecified = nameof(KeyNoItemsSpecified);
     private const string KeySendItemError = nameof(KeySendItemError);
+    private bool initialized;
     
     /// <summary> 发送信息单条长度限制 </summary>
     public const int SendLimit = 490;
@@ -143,6 +144,7 @@ public class ModMailService(
     [UsedImplicitly]
     public List<Warning>? Payment(MongoId sessionId, MongoId moneyId, long amount, PmcData? pmcData = null)
     {
+        Initialize();
         if (!AllowMoneys.Contains(moneyId))
         {
             // 获取允许的货币 ID 列表字符串用于插入到翻译中
@@ -210,6 +212,7 @@ public class ModMailService(
     [UsedImplicitly]
     public List<Warning>? SendMoney(MongoId sessionId, MongoId moneyId, string msg, double amount)
     {
+        Initialize();
         if (!AllowMoneys.Contains(moneyId))
         {
             // 获取允许的货币 ID 列表字符串用于插入到翻译中
@@ -284,6 +287,7 @@ public class ModMailService(
     {
         try
         {
+            Initialize();
             if (items?.Count <= 0)
             {
                 return
@@ -327,6 +331,15 @@ public class ModMailService(
 
     public Task OnLoad()
     {
+        Initialize();
+        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务 ModMailService 已加载完成并初始化国际化");
+        return Task.CompletedTask;
+    }
+
+    private void Initialize()
+    {
+        if (initialized) return;
+        initialized = true;
         I18N i18N = SuntionCoreSPTExtensionsMod.I18NSPTExtensions.Value;
 
         i18N.Expand("ch", new Dictionary<string, string>
@@ -348,8 +361,5 @@ public class ModMailService(
             { KeyNoItemsSpecified, "No items specified" },
             { KeySendItemError, "Error occurred while sending items: {{Error}}" }
         });
-
-        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务 ModMailService 已加载完成并初始化国际化");
-        return Task.CompletedTask;
     }
 }

--- a/SuntionCore.SPTExtensions/Services/ProfileAndAccountService.cs
+++ b/SuntionCore.SPTExtensions/Services/ProfileAndAccountService.cs
@@ -20,6 +20,7 @@ public class ProfileAndAccountService(
     private const string KeyNoPmcDataInstance = nameof(KeyNoPmcDataInstance);
     private const string KeyLoadAccountData = nameof(KeyLoadAccountData);
     private const string KeyAccountIds = nameof(KeyAccountIds);
+    private bool initialized;
     
     /// <summary> Pmc/Scav id 到账户id的映射 </summary>
     private readonly Dictionary<MongoId, MongoId> _playerId2Account = new();
@@ -53,6 +54,7 @@ public class ProfileAndAccountService(
     /// <summary> 维护常用Id映射 </summary>
     public void UpdateAccountData()
     {
+        Initialize();
         Dictionary<MongoId, SptProfile> profiles = saveServer.GetProfiles();
         HashSet<MongoId> accounts = profiles.Keys.ToHashSet();
         _accountIds = accounts;
@@ -79,6 +81,16 @@ public class ProfileAndAccountService(
     
     public Task OnLoad()
     {
+        Initialize();
+        UpdateAccountData();
+        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务ProfileAndAccountService已加载完成");
+        return Task.CompletedTask;
+    }
+
+    private void Initialize()
+    {
+        if (initialized) return;
+        initialized = true;
         SuntionCoreSPTExtensionsMod.I18NSPTExtensions.Value.Expand("ch", new Dictionary<string, string>
         {
             { KeyNoPmcDataInstance, "未找到{{PlayerId}}对应的PmcData实例" },
@@ -91,8 +103,5 @@ public class ProfileAndAccountService(
             { KeyLoadAccountData, "Loading account data from SPT: " },
             { KeyAccountIds, "\n\tAccount ID: {{Account}}, Pmc ID: {{PmcId}}, Scav ID: {{ScavId}}" }
         });
-        UpdateAccountData();
-        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务ProfileAndAccountService已加载完成");
-        return Task.CompletedTask;
     }
 }

--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -52,7 +52,7 @@
               DestinationFolder="$(BeforeZipPath)data\%(RecursiveDir)"/>
         <Copy SourceFiles="@(WWWRootPath)"
               DestinationFolder="$(BeforeZipPath)wwwroot\%(RecursiveDir)"/>
-        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -tzip -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
+        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -t7z -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
     </Target>
 
 

--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
-        <Version>0.1.0</Version>
+        <Version>1.0.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/SuntionCore.SPTExtensions/SuntionCoreSPTExtensionsMod.cs
+++ b/SuntionCore.SPTExtensions/SuntionCoreSPTExtensionsMod.cs
@@ -10,7 +10,7 @@ namespace SuntionCore.SPTExtensions
         public override string Name { get; init; } = "SuntionCore.SPTExtensions";
         public override string Author { get; init; } = "Suntion";
         public override List<string>? Contributors { get; init; } = [];
-        public override SemanticVersioning.Version Version { get; init; } = new("0.1.0");
+        public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
         public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.4");
 
 

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -48,7 +48,7 @@
               DestinationFolder="$(BeforeZipPath)data\%(RecursiveDir)"/>
         <Copy SourceFiles="@(WWWRootPath)"
               DestinationFolder="$(BeforeZipPath)wwwroot\%(RecursiveDir)"/>
-        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -tzip -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
+        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -t7z -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
     </Target>
 
 


### PR DESCRIPTION
fix(i18n): 修复服务初始化时序导致语言包未加载的问题

- 修复与优化：重构 `ModMailService` 和 `ProfileAndAccountService` 的初始化逻辑
  * 新增私有方法 `Initialize()`，采用双重检查锁定模式（通过 `initialized` 标志位）确保国际化配置仅执行一次。
  * 将原本仅在 `OnLoad` 中执行的 I18N 注册逻辑移至 `Initialize()`，并在 `Payment`、`SendMoney`、`SendItems` 及 `UpdateAccountData` 等业务方法入口处显式调用，防止因调用时序早于 `OnLoad` 而导致语言包缺失。
  * 修正 `ProfileAndAccountService` 中 `UpdateAccountData` 的调用时机，确保在记录日志前完成账户数据加载。

- 影响范围：无破坏性变更
  * 内部实现细节调整，对外公开 API 签名保持不变。
  * 解决了在模块完全加载前调用相关服务时，因缺少 "ch" 语言包映射而引发的运行时错误。