### PR TITLE
[DEV] 开发SuntionCore的1.1.*版本

### DIFF
--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -52,7 +52,7 @@
               DestinationFolder="$(BeforeZipPath)data\%(RecursiveDir)"/>
         <Copy SourceFiles="@(WWWRootPath)"
               DestinationFolder="$(BeforeZipPath)wwwroot\%(RecursiveDir)"/>
-        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -tzip -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
+        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -t7z -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
     </Target>
 
 

--- a/SuntionCore/Services/I18NUtil/I18N.cs
+++ b/SuntionCore/Services/I18NUtil/I18N.cs
@@ -89,7 +89,7 @@ public class I18N
             if (value.Length != 2) throw new I18NNameAlreadyExistException(value);
             if (!_i18N.TryGetValue(value, out Dictionary<string, string>? cache))
             {
-                throw new NotLoadLanguageException($"(语言 '{value}' 没有加载)");
+                throw new NotLoadLanguageException($"(设置当前语言时 语言 '{value}' 没有加载)");
             }
             _currentLang = value;
             _sptLocals = null;
@@ -320,7 +320,7 @@ public class I18N
                     return translation;
                 }
                 
-                throw new NotLoadLanguageException();
+                throw new NotLoadLanguageException($"获取语言'{CurrentLang}'的键{key}时没有加载任何语言包");
             }
         }
 

--- a/SuntionCore/Services/LogUtils/ModLogger.cs
+++ b/SuntionCore/Services/LogUtils/ModLogger.cs
@@ -159,7 +159,12 @@ public class ModLogger: IDisposable
 
     private string LogMessage(LogWriterStream type, string msg, Exception? ex = null)
     {
-        if (_disposed) return $"ModLogger({ModName})已销毁";
+        if (_disposed)
+        {
+            string exMsg = ex is not null ? $"错误: {ex.GetType().Name}({ex.Message} Stack: {ex.StackTrace})" : string.Empty;
+            Console.WriteLine($"\033[91m[SuntionCore] Error - 在已经销毁写入流{type.ToString()}的情况下尝试记录日志: {msg} {exMsg}\033[0m");
+            return $"ModLogger({ModName})已销毁";
+        }
         if (type == LogWriterStream.SingleFileStream)
         {
             throw new ArgumentOutOfRangeInThereException(

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -48,7 +48,7 @@
               DestinationFolder="$(BeforeZipPath)data\%(RecursiveDir)"/>
         <Copy SourceFiles="@(WWWRootPath)"
               DestinationFolder="$(BeforeZipPath)wwwroot\%(RecursiveDir)"/>
-        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -tzip -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
+        <Exec WorkingDirectory="$(OutputPath)" Command="$(ZipToolPath) a -t7z -mx=9 $(AssemblyName)-$(Version).7z SPT\"/>
     </Target>
 
 

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
-        <Version>1.0.0</Version>
+        <Version>1.1.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/SuntionCore/SuntionCoreMod.cs
+++ b/SuntionCore/SuntionCoreMod.cs
@@ -15,7 +15,7 @@ namespace SuntionCore
         public override string Name { get; init; } = SuntionCoreLoad.ModName;
         public override string Author { get; init; } = "Suntion";
         public override List<string>? Contributors { get; init; } = [];
-        public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
+        public override SemanticVersioning.Version Version { get; init; } = new("1.1.0");
         public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.4");
 
 


### PR DESCRIPTION
- 版本管理: 更新项目版本号
  * 将 `SuntionCoreMod.cs` 中的 `Version` 属性从 "1.0.0" 升级为 "1.1.0"。
  * 同步更新 `SuntionCore.csproj` 配置文件中的 `<Version>` 标签为 "1.1.0"。

- 错误处理: 增强异常信息的可读性与上下文
  * 在 `I18N.cs` 的 `CurrentLang` 设置逻辑中，细化 `NotLoadLanguageException` 消息，明确指出是“设置当前语言时”目标语言未加载。
  * 在 `I18N.cs` 的翻译获取逻辑中，为 `NotLoadLanguageException` 补充具体上下文，包含当前语言 (`CurrentLang`) 和缺失的键 (`key`) 信息，便于排查问题。