### PR TITLE
chore(core): 升级版本至 1.1.0 并增强日志与异常诊断能力

### DIFF
--- a/SuntionCore/Services/I18NUtil/I18N.cs
+++ b/SuntionCore/Services/I18NUtil/I18N.cs
@@ -89,7 +89,7 @@ public class I18N
             if (value.Length != 2) throw new I18NNameAlreadyExistException(value);
             if (!_i18N.TryGetValue(value, out Dictionary<string, string>? cache))
             {
-                throw new NotLoadLanguageException($"(语言 '{value}' 没有加载)");
+                throw new NotLoadLanguageException($"(设置当前语言时 语言 '{value}' 没有加载)");
             }
             _currentLang = value;
             _sptLocals = null;
@@ -320,7 +320,7 @@ public class I18N
                     return translation;
                 }
                 
-                throw new NotLoadLanguageException();
+                throw new NotLoadLanguageException($"获取语言'{CurrentLang}'的键{key}时没有加载任何语言包");
             }
         }
 

--- a/SuntionCore/Services/LogUtils/ModLogger.cs
+++ b/SuntionCore/Services/LogUtils/ModLogger.cs
@@ -159,7 +159,12 @@ public class ModLogger: IDisposable
 
     private string LogMessage(LogWriterStream type, string msg, Exception? ex = null)
     {
-        if (_disposed) return $"ModLogger({ModName})已销毁";
+        if (_disposed)
+        {
+            string exMsg = ex is not null ? $"错误: {ex.GetType().Name}({ex.Message} Stack: {ex.StackTrace})" : string.Empty;
+            Console.WriteLine($"\033[91m[SuntionCore] Error - 在已经销毁写入流{type.ToString()}的情况下尝试记录日志: {msg} {exMsg}\033[0m");
+            return $"ModLogger({ModName})已销毁";
+        }
         if (type == LogWriterStream.SingleFileStream)
         {
             throw new ArgumentOutOfRangeInThereException(

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
-        <Version>1.0.0</Version>
+        <Version>1.1.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/SuntionCore/SuntionCoreMod.cs
+++ b/SuntionCore/SuntionCoreMod.cs
@@ -15,7 +15,7 @@ namespace SuntionCore
         public override string Name { get; init; } = SuntionCoreLoad.ModName;
         public override string Author { get; init; } = "Suntion";
         public override List<string>? Contributors { get; init; } = [];
-        public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
+        public override SemanticVersioning.Version Version { get; init; } = new("1.1.0");
         public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.4");
 
 


### PR DESCRIPTION
- 版本管理：同步更新核心模块版本号
  * 将 `SuntionCoreMod.cs` 中的 `Version` 属性及 `SuntionCore.csproj` 配置中的 `<Version>` 标签统一升级为 "1.1.0"

- 可观测性优化：增强对象销毁后的日志追踪与异常上下文信息
  * 重构 `ModLogger.LogMessage` 逻辑：当检测到 `_disposed` 状态时，通过 `Console.WriteLine` 输出红色高亮错误日志，完整记录流类型 (`LogWriterStream`)、原始消息及异常堆栈 (`StackTrace`)，防止静默失败
  * 细化 `I18N` 异常提示：在 `NotLoadLanguageException` 中明确区分“设置当前语言”与“获取翻译键”两种场景，并在报错信息中动态注入 `CurrentLang` 和缺失的 `key`，提升排查效率