### PR TITLE
[SPTExtensions v1.0.0 Release] fix(i18n): 修复服务初始化时序导致语言包缺失并发布正式版

### DIFF
--- a/SuntionCore.SPTExtensions/Services/ModMailService.cs
+++ b/SuntionCore.SPTExtensions/Services/ModMailService.cs
@@ -30,6 +30,7 @@ public class ModMailService(
     private const string KeySendMoneyError = nameof(KeySendMoneyError);
     private const string KeyNoItemsSpecified = nameof(KeyNoItemsSpecified);
     private const string KeySendItemError = nameof(KeySendItemError);
+    private bool initialized;
     
     /// <summary> 发送信息单条长度限制 </summary>
     public const int SendLimit = 490;
@@ -143,6 +144,7 @@ public class ModMailService(
     [UsedImplicitly]
     public List<Warning>? Payment(MongoId sessionId, MongoId moneyId, long amount, PmcData? pmcData = null)
     {
+        Initialize();
         if (!AllowMoneys.Contains(moneyId))
         {
             // 获取允许的货币 ID 列表字符串用于插入到翻译中
@@ -210,6 +212,7 @@ public class ModMailService(
     [UsedImplicitly]
     public List<Warning>? SendMoney(MongoId sessionId, MongoId moneyId, string msg, double amount)
     {
+        Initialize();
         if (!AllowMoneys.Contains(moneyId))
         {
             // 获取允许的货币 ID 列表字符串用于插入到翻译中
@@ -284,6 +287,7 @@ public class ModMailService(
     {
         try
         {
+            Initialize();
             if (items?.Count <= 0)
             {
                 return
@@ -327,6 +331,15 @@ public class ModMailService(
 
     public Task OnLoad()
     {
+        Initialize();
+        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务 ModMailService 已加载完成并初始化国际化");
+        return Task.CompletedTask;
+    }
+
+    private void Initialize()
+    {
+        if (initialized) return;
+        initialized = true;
         I18N i18N = SuntionCoreSPTExtensionsMod.I18NSPTExtensions.Value;
 
         i18N.Expand("ch", new Dictionary<string, string>
@@ -348,8 +361,5 @@ public class ModMailService(
             { KeyNoItemsSpecified, "No items specified" },
             { KeySendItemError, "Error occurred while sending items: {{Error}}" }
         });
-
-        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务 ModMailService 已加载完成并初始化国际化");
-        return Task.CompletedTask;
     }
 }

--- a/SuntionCore.SPTExtensions/Services/ProfileAndAccountService.cs
+++ b/SuntionCore.SPTExtensions/Services/ProfileAndAccountService.cs
@@ -20,6 +20,7 @@ public class ProfileAndAccountService(
     private const string KeyNoPmcDataInstance = nameof(KeyNoPmcDataInstance);
     private const string KeyLoadAccountData = nameof(KeyLoadAccountData);
     private const string KeyAccountIds = nameof(KeyAccountIds);
+    private bool initialized;
     
     /// <summary> Pmc/Scav id 到账户id的映射 </summary>
     private readonly Dictionary<MongoId, MongoId> _playerId2Account = new();
@@ -53,6 +54,7 @@ public class ProfileAndAccountService(
     /// <summary> 维护常用Id映射 </summary>
     public void UpdateAccountData()
     {
+        Initialize();
         Dictionary<MongoId, SptProfile> profiles = saveServer.GetProfiles();
         HashSet<MongoId> accounts = profiles.Keys.ToHashSet();
         _accountIds = accounts;
@@ -79,6 +81,16 @@ public class ProfileAndAccountService(
     
     public Task OnLoad()
     {
+        Initialize();
+        UpdateAccountData();
+        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务ProfileAndAccountService已加载完成");
+        return Task.CompletedTask;
+    }
+
+    private void Initialize()
+    {
+        if (initialized) return;
+        initialized = true;
         SuntionCoreSPTExtensionsMod.I18NSPTExtensions.Value.Expand("ch", new Dictionary<string, string>
         {
             { KeyNoPmcDataInstance, "未找到{{PlayerId}}对应的PmcData实例" },
@@ -91,8 +103,5 @@ public class ProfileAndAccountService(
             { KeyLoadAccountData, "Loading account data from SPT: " },
             { KeyAccountIds, "\n\tAccount ID: {{Account}}, Pmc ID: {{PmcId}}, Scav ID: {{ScavId}}" }
         });
-        UpdateAccountData();
-        SuntionCoreSPTExtensionsMod.Logger.Value.Info("服务ProfileAndAccountService已加载完成");
-        return Task.CompletedTask;
     }
 }

--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
-        <Version>0.1.0</Version>
+        <Version>1.0.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/SuntionCore.SPTExtensions/SuntionCoreSPTExtensionsMod.cs
+++ b/SuntionCore.SPTExtensions/SuntionCoreSPTExtensionsMod.cs
@@ -10,7 +10,7 @@ namespace SuntionCore.SPTExtensions
         public override string Name { get; init; } = "SuntionCore.SPTExtensions";
         public override string Author { get; init; } = "Suntion";
         public override List<string>? Contributors { get; init; } = [];
-        public override SemanticVersioning.Version Version { get; init; } = new("0.1.0");
+        public override SemanticVersioning.Version Version { get; init; } = new("1.0.0");
         public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.4");
 
 


### PR DESCRIPTION
- 核心修复：重构 `ModMailService` 与 `ProfileAndAccountService` 初始化流程以解决竞态条件
  * 新增私有 `Initialize()` 方法，采用双重检查锁定模式（基于 `initialized` 标志位）确保 I18N 注册逻辑仅执行一次
  * 将原局限于 `OnLoad` 的生命周期钩子逻辑下沉至业务层，在 `Payment`, `SendMoney`, `SendItems`, `UpdateAccountData` 等方法入口处显式调用 `Initialize()`，防止因外部调用早于模块加载完成而抛出“语言包未加载”异常
  * 修正 `ProfileAndAccountService.UpdateAccountData` 执行顺序，确保在记录日志前完成账户数据预热

- 版本发布：正式升级项目至稳定版 1.0.0
  * 更新 `SuntionCoreSPTExtensionsMod.cs` 的 `Version` 属性及 `SuntionCore.SPTExtensions.csproj` 配置，版本号从 `0.1.0` 提升至 `1.0.0`
  * 此次升级标志着核心扩展模块结束预览状态，无破坏性 API 变更