### PR TITLE
[Chore]: 清理 IDE 冗余配置并为 NuGet 打包添加元数据支持

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,105 +4,29 @@ on:
     branches:
       - master
 jobs:
-  publish_suntion:
-    name: build, pack & publish
+  build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for this job
+    
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      # - name: Setup dotnet
-      #   uses: actions/setup-dotnet@v1.5.0
-      #   with:
-      #     dotnet-version: 3.1.200
-
-      # Publish
-      - name: publish on version change for SuntionCore
-        id: publish_nuget
-        uses: brandedoutcast/publish-nuget@v2.5.5
+      # Build your artifacts/my-sdk.nupkg package here
+      - name: Pack specific projects
+        run: |
+          dotnet pack SuntionCore/SuntionCore.csproj -c Release -o artifacts
+          dotnet pack SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj -c Release -o artifacts
+    
+      # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
         with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: SuntionCore/SuntionCore.csproj
-
-          # Configuration to build and package
-          BUILD_CONFIGURATION: Release
-
-          # Platform target to compile (default is empty/AnyCPU)
-          # BUILD_PLATFORM: x64
-
-          # NuGet package id, used for version detection & defaults to project name
-          # PACKAGE_NAME: Core
-
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          # VERSION_FILE_PATH: Directory.Build.props
-
-          # Regex pattern to extract version info in a capturing group
-          # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-
-          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-          # VERSION_STATIC: 1.0.0
-
-          # Flag to toggle git tagging, enabled by default
-          # TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          # TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          # NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          # NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
-  publish_suntion_extensions:
-    name: build, pack & publish
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6.0.2
-
-      # - name: Setup dotnet
-      #   uses: actions/setup-dotnet@v1.5.0
-      #   with:
-      #     dotnet-version: 3.1.200
-
-      # Publish
-      - name: publish on version change for SuntionCore.SPTExtensions
-        id: publish_nuget
-        uses: brandedoutcast/publish-nuget@v2.5.5
-        with:
-          # Filepath of the project to be packaged, relative to root of repository
-          PROJECT_FILE_PATH: SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
-
-          # Configuration to build and package
-          BUILD_CONFIGURATION: Release
-
-          # Platform target to compile (default is empty/AnyCPU)
-          # BUILD_PLATFORM: x64
-
-          # NuGet package id, used for version detection & defaults to project name
-          # PACKAGE_NAME: Core
-
-          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
-          # VERSION_FILE_PATH: Directory.Build.props
-
-          # Regex pattern to extract version info in a capturing group
-          # VERSION_REGEX: ^\s*<Version>(.*)<\/Version>\s*$
-
-          # Useful with external providers like Nerdbank.GitVersioning, ignores VERSION_FILE_PATH & VERSION_REGEX
-          # VERSION_STATIC: 1.0.0
-
-          # Flag to toggle git tagging, enabled by default
-          # TAG_COMMIT: true
-
-          # Format of the git tag, [*] gets replaced with actual version
-          # TAG_FORMAT: v*
-
-          # API key to authenticate with NuGet server
-          # NUGET_KEY: ${{secrets.NUGET_API_KEY}}
-
-          # NuGet server uri hosting the packages, defaults to https://api.nuget.org
-          # NUGET_SOURCE: https://api.nuget.org
-
-          # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
-          # INCLUDE_SYMBOLS: false
+          user: contoso-bot # Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
+    
+      # Push the package
+      - name: NuGet push with wildcard
+        run: |
+          # 推送所有 SuntionCore 相关包
+          dotnet nuget push "artifacts/SuntionCore*.nupkg" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      # - name: NuGet push
+      #   run: dotnet nuget push artifacts/my-sdk.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -64,13 +64,6 @@
         <None Remove="Services\SPTUtils\**" />
     </ItemGroup>
 
-
-    <ItemGroup>
-        <Content Include="SuntionCore.csproj.user" />
-        <Content Include="SuntionCore.SPTExtensions.user" />
-    </ItemGroup>
-
-
     <ItemGroup>
       <Compile Remove="Services\SPTUtils\**" />
     </ItemGroup>

--- a/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
+++ b/SuntionCore.SPTExtensions/SuntionCore.SPTExtensions.csproj
@@ -7,6 +7,9 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
+        <PackageId>SuntionCore.SPTExtensions</PackageId>
+        <Authors>Suntion</Authors>
+        <Company>Suntion</Company>
         <Version>1.0.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -59,11 +59,6 @@
         <None Include="$(MSBuildProjectFullPath).user" Condition="Exists('$(MSBuildProjectFullPath).user')"/>
     </ItemGroup>
 
-
-    <ItemGroup>
-      <Content Include="SuntionCore.csproj.user" />
-    </ItemGroup>
-
     <Target Name="拷贝模组到SPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">
         <!-- 定义变量 -->
         <PropertyGroup>

--- a/SuntionCore/SuntionCore.csproj
+++ b/SuntionCore/SuntionCore.csproj
@@ -7,6 +7,9 @@
         <Nullable>enable</Nullable>
         <OutputType>Library</OutputType>
         <EnableDefaultContentItems>false</EnableDefaultContentItems>
+        <PackageId>SuntionCore</PackageId>
+        <Authors>Suntion</Authors>
+        <Company>Suntion</Company>
         <Version>1.2.0</Version>
         <!-- The two lines below will set the output path for the binaries -->
         <OutputPath>bin\$(Configuration)\$(ProjectName)\$(AssemblyName)\</OutputPath>


### PR DESCRIPTION
## 变更详情

### fix(project): 清理 Rider 自动添加的冗余 .user 文件配置

- **问题描述**：Rider IDE 会自动生成 `.user` 文件，并可能将其以 `<Content>` 形式误加入项目文件中。
- **修复内容**：
  - 从 `SuntionCore.SPTExtensions.csproj` 中移除 `SuntionCore.SPTExtensions.user` 与 `SuntionCore.csproj.user` 的 `<Content>` 引用
  - 清理 `SuntionCore.csproj` 中重复的 `SuntionCore.csproj.user` 导入

### build(core): 配置项目元数据以支持 NuGet 打包

- **新增内容**：为支持 NuGet 包发布，在项目文件中添加必要元数据：
  - `SuntionCore.csproj`：新增 `PackageId`、`Authors`、`Company` 属性
  - `SuntionCore.SPTExtensions.csproj`：新增 `PackageId`、`Authors`、`Company` 属性

### refactor(publish): 重构 NuGet 发布的 GitHub Actions 工作流

- **变更目标**：提升 CI 流水线的清晰度与可维护性
- **主要改动**：
  - 合并冗余的构建与发布任务
  - 优化步骤顺序与命名，提升可读性
  - 集成官方 `nuget-org/trusted-publishing` 机制，增强发布安全性


